### PR TITLE
[bugfix] Add improved handling for host link detection

### DIFF
--- a/link/link_linux.go
+++ b/link/link_linux.go
@@ -40,39 +40,26 @@ var (
 // The function will not fail if a link is down, but will fail if a link does not exist
 func HostLinks(names ...string) (Links, error) {
 	if len(names) == 0 {
-		linkDir, err := os.OpenFile(netBasePath, os.O_RDONLY, 0600)
+		var err error
+		names, err = hostLinkNamesFromSysfs()
 		if err != nil {
+			if isSysfsUnavailableErr(err) {
+				return hostLinksFromNetlink()
+			}
 			return nil, err
 		}
-		defer func() {
-			if cerr := linkDir.Close(); cerr != nil && err == nil {
-				err = cerr
-			}
-		}()
 
-		direEnts, err := linkDir.Readdir(-1)
-		if err != nil {
-			return nil, err
-		}
-		names = make([]string, 0, len(direEnts))
-		for _, ent := range direEnts {
-
-			// Regular files are not interfaces, so we skip them. This is a sanity check to avoid trying to parse non-interface entries in the directory.
-			if !ent.Mode().IsRegular() {
-				names = append(names, ent.Name())
-			}
-		}
+		return hostLinksByNames(names)
 	}
 
-	ifaces := make([]*Link, len(names))
-	var err error
-	for i, name := range names {
-		if ifaces[i], err = newLink(name); err != nil {
-			return nil, err
+	if err := ensureSysfsNetBaseReadable(); err != nil {
+		if isSysfsUnavailableErr(err) {
+			return hostLinksFromNetlink(names...)
 		}
+		return nil, err
 	}
 
-	return ifaces, nil
+	return hostLinksByNames(names)
 }
 
 // IsUp determines if an interface is currently up (at the time of the call)
@@ -237,4 +224,214 @@ func newAddr(ifam *syscall.IfAddrmsg, attrs []syscall.NetlinkRouteAttr) net.IP {
 		}
 	}
 	return nil
+}
+
+func hostLinkNamesFromSysfs() (names []string, err error) {
+	linkDir, err := os.Open(netBasePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := linkDir.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	dirEnts, err := linkDir.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	names = make([]string, 0, len(dirEnts))
+	for _, ent := range dirEnts {
+		mode := ent.Type()
+		if mode&os.ModeSymlink != 0 {
+			names = append(names, ent.Name())
+			continue
+		}
+
+		if mode == 0 {
+			info, ierr := os.Lstat(netBasePath + ent.Name())
+			if ierr != nil {
+				return nil, ierr
+			}
+
+			if info.Mode()&os.ModeSymlink != 0 {
+				names = append(names, ent.Name())
+			}
+		}
+	}
+
+	return names, nil
+}
+
+func ensureSysfsNetBaseReadable() error {
+	linkDir, err := os.Open(netBasePath)
+	if err != nil {
+		return err
+	}
+	return linkDir.Close()
+}
+
+func hostLinksByNames(names []string) (Links, error) {
+	ifaces := make([]*Link, len(names))
+	for i, name := range names {
+		link, err := newLink(name)
+		if err != nil {
+			return nil, err
+		}
+		ifaces[i] = link
+	}
+
+	return ifaces, nil
+}
+
+func hostLinksFromNetlink(names ...string) (Links, error) {
+	links, err := parseNetlinkLinks()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(names) == 0 {
+		return links, nil
+	}
+
+	return selectLinksByName(links, names)
+}
+
+func parseNetlinkLinks() (Links, error) {
+	tab, err := syscall.NetlinkRIB(syscall.RTM_GETLINK, syscall.AF_UNSPEC)
+	if err != nil {
+		return nil, os.NewSyscallError("netlinkrib", err)
+	}
+
+	msgs, err := syscall.ParseNetlinkMessage(tab)
+	if err != nil {
+		return nil, os.NewSyscallError("parsenetlinkmessage", err)
+	}
+
+	links := make(Links, 0, len(msgs))
+loop:
+	for _, m := range msgs {
+		switch m.Header.Type {
+		case syscall.NLMSG_DONE:
+			break loop
+		case syscall.RTM_NEWLINK:
+			if len(m.Data) < syscall.SizeofIfInfomsg {
+				continue
+			}
+
+			ifim := (*syscall.IfInfomsg)(unsafe.Pointer(&m.Data[0])) // #nosec G103
+			attrs, err := syscall.ParseNetlinkRouteAttr(&m)
+			if err != nil {
+				return nil, os.NewSyscallError("parsenetlinkrouteattr", err)
+			}
+
+			link := &Link{
+				Index: int(ifim.Index),
+				Type:  Type(ifim.Type),
+			}
+
+			for _, attr := range attrs {
+				switch routeAttrType(attr.Attr.Type) {
+				case syscall.IFLA_IFNAME:
+					link.Name = strings.TrimRight(string(attr.Value), "\x00")
+				case syscall.IFLA_LINKINFO:
+					link.IsVLAN = parseLinkInfoIsVLAN(attr.Value)
+				}
+			}
+
+			if link.Name != "" {
+				links = append(links, link)
+			}
+		}
+	}
+
+	return links, nil
+}
+
+func selectLinksByName(links Links, names []string) (Links, error) {
+	linksByName := make(map[string]*Link, len(links))
+	for _, link := range links {
+		if link == nil || link.Name == "" {
+			continue
+		}
+		if _, ok := linksByName[link.Name]; !ok {
+			linksByName[link.Name] = link
+		}
+	}
+
+	selectedLinks := make(Links, len(names))
+	for i, name := range names {
+		link, ok := linksByName[name]
+		if !ok {
+			return nil, &os.PathError{
+				Op:   "open",
+				Path: netBasePath + name + netUEventPath,
+				Err:  os.ErrNotExist,
+			}
+		}
+
+		linkCpy := *link
+		selectedLinks[i] = &linkCpy
+	}
+
+	return selectedLinks, nil
+}
+
+func routeAttrType(attrType uint16) uint16 {
+	return attrType & ^uint16(unix.NLA_F_NESTED|unix.NLA_F_NET_BYTEORDER)
+}
+
+func parseRouteAttrs(data []byte) ([]syscall.NetlinkRouteAttr, error) {
+	attrs := make([]syscall.NetlinkRouteAttr, 0, 4)
+	for len(data) >= syscall.SizeofRtAttr {
+		attr := (*syscall.RtAttr)(unsafe.Pointer(&data[0])) // #nosec G103
+		if int(attr.Len) < syscall.SizeofRtAttr || int(attr.Len) > len(data) {
+			return nil, syscall.EINVAL
+		}
+
+		attrs = append(attrs, syscall.NetlinkRouteAttr{
+			Attr:  *attr,
+			Value: data[syscall.SizeofRtAttr:int(attr.Len)],
+		})
+
+		next := (int(attr.Len) + syscall.RTA_ALIGNTO - 1) & ^(syscall.RTA_ALIGNTO - 1)
+		if next > len(data) {
+			return nil, syscall.EINVAL
+		}
+		data = data[next:]
+	}
+
+	return attrs, nil
+}
+
+func parseLinkInfoIsVLAN(data []byte) bool {
+	attrs, err := parseRouteAttrs(data)
+	if err != nil {
+		return false
+	}
+
+	for _, attr := range attrs {
+		if routeAttrType(attr.Attr.Type) != unix.IFLA_INFO_KIND {
+			continue
+		}
+
+		if strings.EqualFold(strings.TrimRight(string(attr.Value), "\x00"), netUEventDevTypeVLAN) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isSysfsUnavailableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, syscall.ENOTDIR) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
 }

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -7,10 +7,14 @@ import (
 	"errors"
 	"io/fs"
 	"net"
+	"os"
+	"syscall"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestIsUp(t *testing.T) {
@@ -346,6 +350,143 @@ func BenchmarkGetIPs(b *testing.B) {
 			_, _ = iface.Addrs()
 		}
 	})
+}
+
+func TestIsSysfsUnavailableErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "not-exist",
+			err:  os.ErrNotExist,
+			want: true,
+		},
+		{
+			name: "path-error-not-exist",
+			err: &os.PathError{
+				Op:   "open",
+				Path: netBasePath,
+				Err:  os.ErrNotExist,
+			},
+			want: true,
+		},
+		{
+			name: "enotdir",
+			err:  syscall.ENOTDIR,
+			want: true,
+		},
+		{
+			name: "eacces",
+			err:  syscall.EACCES,
+			want: true,
+		},
+		{
+			name: "eperm",
+			err:  syscall.EPERM,
+			want: true,
+		},
+		{
+			name: "einval",
+			err:  syscall.EINVAL,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isSysfsUnavailableErr(tt.err))
+		})
+	}
+}
+
+func TestParseLinkInfoIsVLAN(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{
+			name: "empty",
+			data: nil,
+			want: false,
+		},
+		{
+			name: "malformed",
+			data: []byte{0x01, 0x02},
+			want: false,
+		},
+		{
+			name: "kind-vlan",
+			data: encodeRtAttr(unix.IFLA_INFO_KIND, []byte("vlan\x00")),
+			want: true,
+		},
+		{
+			name: "kind-bridge",
+			data: encodeRtAttr(unix.IFLA_INFO_KIND, []byte("bridge\x00")),
+			want: false,
+		},
+		{
+			name: "kind-vlan-nested-flag",
+			data: encodeRtAttr(unix.IFLA_INFO_KIND|unix.NLA_F_NESTED, []byte("vlan\x00")),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseLinkInfoIsVLAN(tt.data))
+		})
+	}
+}
+
+func TestSelectLinksByName(t *testing.T) {
+	t.Run("order-and-duplicates", func(t *testing.T) {
+		links := Links{
+			{Name: "eth0", Index: 2, Type: TypeEthernet},
+			{Name: "lo", Index: 1, Type: TypeLoopback},
+		}
+
+		got, err := selectLinksByName(links, []string{"lo", "eth0", "lo"})
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		require.Equal(t, "lo", got[0].Name)
+		require.Equal(t, "eth0", got[1].Name)
+		require.Equal(t, "lo", got[2].Name)
+		require.NotSame(t, got[0], got[2])
+	})
+
+	t.Run("missing-link", func(t *testing.T) {
+		links := Links{{Name: "eth0", Index: 2, Type: TypeEthernet}}
+
+		_, err := selectLinksByName(links, []string{"doesnotexist"})
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		var perr *os.PathError
+		require.ErrorAs(t, err, &perr)
+		require.Equal(t, netBasePath+"doesnotexist"+netUEventPath, perr.Path)
+	})
+}
+
+func encodeRtAttr(attrType uint16, value []byte) []byte {
+	rawLen := syscall.SizeofRtAttr + len(value)
+	alignedLen := (rawLen + syscall.RTA_ALIGNTO - 1) & ^(syscall.RTA_ALIGNTO - 1)
+
+	b := make([]byte, alignedLen)
+	*(*syscall.RtAttr)(unsafe.Pointer(&b[0])) = syscall.RtAttr{ // #nosec G103
+		Len:  uint16(rawLen),
+		Type: attrType,
+	}
+	copy(b[syscall.SizeofRtAttr:], value)
+
+	return b
 }
 
 type mockInterfaces struct {


### PR DESCRIPTION
Follow-up to #22
Closes #23 

## Summary
This change hardens and speeds up `HostLinks()` while preserving existing API behavior.
- Switched sysfs enumeration to `ReadDir` and include only symlink entries in `/sys/class/net/`.
- Added fallback to netlink (`RTM_GETLINK`) **only** when `/sys/class/net/` is unavailable/unreadable (`ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`).
- Kept current behavior when sysfs is available, including explicit-name error semantics.
- In fallback mode, populated `Name`, `Index`, `Type`, and VLAN hint (`IFLA_LINKINFO/IFLA_INFO_KIND == vlan`).

## Why
- Avoid parsing non-interface files such as `bonding_masters`.
- Improve robustness on systems where sysfs is missing or restricted.
- Keep performance-oriented interface discovery without broad behavior changes.

## Validation
- Added targeted tests for:
  - sysfs-unavailable error classification,
  - VLAN kind parsing from netlink attrs,
  - name selection semantics (order, duplicates, missing interfaces).
